### PR TITLE
Add global block syntax

### DIFF
--- a/syntaxes/polar.tmLanguage.json
+++ b/syntaxes/polar.tmLanguage.json
@@ -80,13 +80,16 @@
     },
     "resource-block": {
       "name": "meta.resource-block",
-      "begin": "(resource|actor)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:::[a-zA-Z0-9_]+)*)\\s*\\{",
+      "begin": "((resource|actor)\\s+([a-zA-Z_][a-zA-Z0-9_]*(?:::[a-zA-Z0-9_]+)*)|(global))\\s*\\{",
       "beginCaptures": {
-        "1": {
+        "2": {
           "name": "keyword.control"
         },
-        "2": {
+        "3": {
           "name": "entity.name.type"
+        },
+        "4": {
+          "name": "keyword.control"
         }
       },
       "end": "\\}",
@@ -214,7 +217,7 @@
     "keyword": {
       "patterns": [
         {
-          "match": "\\b(cut|or|debug|print|in|forall|if|and|of|not|matches|type|on)\\b",
+          "match": "\\b(cut|or|debug|print|in|forall|if|and|of|not|matches|type|on|global)\\b",
           "name": "constant.character"
         }
       ]


### PR DESCRIPTION
Adds `global {` as a valid way to start a `resource-block` (so we don't have to repeat all the patterns defined in `resource-block`) and adds `global` as a keyword.

That ends up looking like this:
<img width="407" alt="Screen Shot 2023-01-09 at 11 34 46 AM" src="https://user-images.githubusercontent.com/3970187/211359569-dcc29a3e-00f8-46a3-8c90-dd192c501fc4.png">

(Line 11 in that screenshot isn't really germane, feel free to ignore it.)