### PR TITLE
Bugfix: add support for comments in test blocks

### DIFF
--- a/syntaxes/polar.tmLanguage.json
+++ b/syntaxes/polar.tmLanguage.json
@@ -148,6 +148,9 @@
           "patterns": [
             {
               "include": "#rule"
+            },
+            {
+              "include": "#comment"
             }
           ]
         },
@@ -157,6 +160,9 @@
         {
           "name": "keyword.other",
           "match": "\\b(assert|assert_not)\\b"
+        },
+        {
+          "include": "#comment"
         }
       ]
     },


### PR DESCRIPTION
Forgot to do this in #3.

Looks like this:
<img width="599" alt="Screen Shot 2023-01-20 at 10 57 56 AM" src="https://user-images.githubusercontent.com/3970187/213745561-6f7b72fc-3f9d-4d6c-9264-3afbaa7279d9.png">
